### PR TITLE
Support arithmetic expressions in limit clause

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -757,8 +757,7 @@ module.exports = grammar({
     limit_clause: $ =>
       seq(
         kw("LIMIT"),
-        choice($.number, kw("ALL")),
-        optional(seq(",", $.number)), // MySQL LIMIT a, b
+        choice(kw("ALL"), $.number, $.binary_expression, $.unary_expression)
       ),
     offset_clause: $ =>
       prec.right(

--- a/grammar.js
+++ b/grammar.js
@@ -757,7 +757,7 @@ module.exports = grammar({
     limit_clause: $ =>
       seq(
         kw("LIMIT"),
-        choice(kw("ALL"), $.number, $.binary_expression, $.unary_expression)
+        choice(kw("ALL"), $._expression)
       ),
     offset_clause: $ =>
       prec.right(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8432,15 +8432,7 @@
             },
             {
               "type": "SYMBOL",
-              "name": "number"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "binary_expression"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "unary_expression"
+              "name": "_expression"
             }
           ]
         }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8415,10 +8415,6 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "number"
-            },
-            {
               "type": "ALIAS",
               "content": {
                 "type": "TOKEN",
@@ -8433,27 +8429,18 @@
               },
               "named": false,
               "value": "ALL"
-            }
-          ]
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "number"
-                }
-              ]
             },
             {
-              "type": "BLANK"
+              "type": "SYMBOL",
+              "name": "number"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "binary_expression"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "unary_expression"
             }
           ]
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5533,11 +5533,19 @@
     "named": true,
     "fields": {},
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
+          "type": "binary_expression",
+          "named": true
+        },
+        {
           "type": "number",
+          "named": true
+        },
+        {
+          "type": "unary_expression",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -5537,11 +5537,111 @@
       "required": false,
       "types": [
         {
+          "type": "FALSE",
+          "named": true
+        },
+        {
+          "type": "NULL",
+          "named": true
+        },
+        {
+          "type": "TRUE",
+          "named": true
+        },
+        {
+          "type": "all_some_any_subquery_expression",
+          "named": true
+        },
+        {
+          "type": "argument_reference",
+          "named": true
+        },
+        {
+          "type": "array_element_access",
+          "named": true
+        },
+        {
+          "type": "asterisk_expression",
+          "named": true
+        },
+        {
+          "type": "at_time_zone_expression",
+          "named": true
+        },
+        {
+          "type": "between_and_expression",
+          "named": true
+        },
+        {
           "type": "binary_expression",
           "named": true
         },
         {
+          "type": "boolean_expression",
+          "named": true
+        },
+        {
+          "type": "conditional_expression",
+          "named": true
+        },
+        {
+          "type": "dotted_name",
+          "named": true
+        },
+        {
+          "type": "exists_subquery_expression",
+          "named": true
+        },
+        {
+          "type": "function_call",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "in_expression",
+          "named": true
+        },
+        {
+          "type": "in_subquery_expression",
+          "named": true
+        },
+        {
+          "type": "interval_expression",
+          "named": true
+        },
+        {
+          "type": "is_expression",
+          "named": true
+        },
+        {
+          "type": "json_access",
+          "named": true
+        },
+        {
+          "type": "like_expression",
+          "named": true
+        },
+        {
           "type": "number",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
+          "type": "select_subexpression",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        },
+        {
+          "type": "type_cast",
           "named": true
         },
         {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,6 +1,6 @@
 #include <tree_sitter/parser.h>
-#include <string>
-#include <cwctype>
+#include "string"
+#include "cwctype"
 
 namespace {
 

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -13,9 +13,8 @@ extern "C" {
 #define ts_builtin_sym_end 0
 #define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
 
-typedef uint16_t TSStateId;
-
 #ifndef TREE_SITTER_API_H_
+typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
@@ -130,9 +129,16 @@ struct TSLanguage {
  *  Lexer Macros
  */
 
+#ifdef _MSC_VER
+#define UNUSED __pragma(warning(suppress : 4101))
+#else
+#define UNUSED __attribute__((unused))
+#endif
+
 #define START_LEXER()           \
   bool result = false;          \
   bool skip = false;            \
+  UNUSED                        \
   bool eof = false;             \
   int32_t lookahead;            \
   goto start;                   \
@@ -166,7 +172,7 @@ struct TSLanguage {
  *  Parse Table Macros
  */
 
-#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+#define SMALL_STATE(id) ((id) - LARGE_STATE_COUNT)
 
 #define STATE(id) id
 
@@ -176,7 +182,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value            \
+      .state = (state_value)          \
     }                                 \
   }}
 
@@ -184,7 +190,7 @@ struct TSLanguage {
   {{                                  \
     .shift = {                        \
       .type = TSParseActionTypeShift, \
-      .state = state_value,           \
+      .state = (state_value),         \
       .repetition = true              \
     }                                 \
   }}

--- a/test/corpus/insert.txt
+++ b/test/corpus/insert.txt
@@ -120,7 +120,8 @@ INSERT statement values with limit
 
 INSERT INTO table1 VALUES (1, 'a'), (2, 'b') LIMIT 1;
 INSERT INTO table1 VALUES (1, 'a'), (2, 'b') LIMIT ALL;
-INSERT INTO table1 VALUES (1, 'a'), (2, 'b') LIMIT 1, 1;
+INSERT INTO table1 VALUES (1, 'a'), (2, 'b') LIMIT +1;
+INSERT INTO table1 VALUES (1, 'a'), (2, 'b') LIMIT 1 + 2;
 
 --------------------------------------------------------------------------------
 
@@ -162,8 +163,23 @@ INSERT INTO table1 VALUES (1, 'a'), (2, 'b') LIMIT 1, 1;
         (string
           (content)))
       (limit_clause
+        (unary_expression
+          (number)))))
+  (insert_statement
+    (identifier)
+    (values_clause
+      (values_clause_item
         (number)
-        (number)))))
+        (string
+          (content)))
+      (values_clause_item
+        (number)
+        (string
+          (content)))
+      (limit_clause
+        (binary_expression
+          (number)
+          (number))))))
 
 ================================================================================
 INSERT statement values with offset

--- a/test/corpus/select.txt
+++ b/test/corpus/select.txt
@@ -207,8 +207,10 @@ FROM table1 AS t, table2 t2, table3
 SELECT with limit
 ================================================================================
 
+SELECT * FROM foo LIMIT ALL;
 SELECT * FROM foo LIMIT 10;
-SELECT * FROM foo LIMIT 10, 5;
+SELECT * FROM foo LIMIT +10;
+SELECT * FROM foo LIMIT 1 + 2;
 SELECT * FROM foo LIMIT 10 OFFSET 5;
 
 --------------------------------------------------------------------------------
@@ -220,6 +222,13 @@ SELECT * FROM foo LIMIT 10 OFFSET 5;
         (asterisk_expression)))
     (from_clause
       (identifier))
+    (limit_clause))
+  (select_statement
+    (select_clause
+      (select_clause_body
+        (asterisk_expression)))
+    (from_clause
+      (identifier))
     (limit_clause
       (number)))
   (select_statement
@@ -229,8 +238,18 @@ SELECT * FROM foo LIMIT 10 OFFSET 5;
     (from_clause
       (identifier))
     (limit_clause
-      (number)
-      (number)))
+      (unary_expression
+        (number))))
+  (select_statement
+    (select_clause
+      (select_clause_body
+        (asterisk_expression)))
+    (from_clause
+      (identifier))
+    (limit_clause
+      (binary_expression
+        (number)
+        (number))))
   (select_statement
     (select_clause
       (select_clause_body


### PR DESCRIPTION
`LIMIT` 句の中で算術式が書けるよう、文法定義の変更を行いました。

- ~具体的には、`unary_expression` と `binary_expression` を追加しています。~ 
  - `_expresssion` を追加しました。
  - [PostgreSQLのgrammar](https://github.com/postgres/postgres/blob/master/src/backend/parser/gram.y#L13247)に倣っています
- 変更前はMySQLの機能である `limit a, b` (`limit b offset a`と等価) という記述がサポートされていましたが、文法定義が煩雑になりそうなためと、uroboroSQL-fmtはPostgreSQL準拠となっているためサポート外としました。

```sql
-- 変わらず有効な記述
SELECT * FROM foo LIMIT ALL;
SELECT * FROM foo LIMIT 10;

-- 新しく書けるようになる記述
SELECT * FROM foo LIMIT +10;
SELECT * FROM foo LIMIT 1 + 2;
SELECT * FROM foo LIMIT (1 + 2);

-- 書けなくなる記述
SELECT * FROM foo LIMIT 2, 1;
```
